### PR TITLE
QA-103 Add ansible error to assertion error text for failed actions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     include_package_data=True,
-    version="3.2.1",
+    version="3.2.3",
     # the following makes a plugin available to pytest
     entry_points={"pytest11": ["adcm_pytest_plugin = adcm_pytest_plugin.plugin"]},
     # custom PyPI classifier for pytest plugins

--- a/src/adcm_pytest_plugin/steps/actions.py
+++ b/src/adcm_pytest_plugin/steps/actions.py
@@ -24,20 +24,71 @@ from adcm_client.objects import Cluster, Service, Host, Task, Component
 from .asserts import assert_action_result
 
 
+def _get_error_text_from_task_logs(task: Task):
+    error_text = ""
+    for job in task.job_list():
+        for log in job.log_list():
+            error_text += _extract_error_from_ansible_log(log)
+    return error_text
+
+
+def _extract_error_from_ansible_log(log: str):
+    """
+    Extract ansible error message from ansible log
+
+    >>> _extract_error_from_ansible_log("fatal: Some ERROR\\nTASK [api : something] **********")
+    'fatal: Some ERROR\\n'
+    >>> _extract_error_from_ansible_log(
+    ...     "TASK [api : something] **********\\nok: [adcm-cluster-adb-gw0-e330benhwqir]\\n msg: All assertions passed"
+    ... )
+
+    >>> _extract_error_from_ansible_log(
+    ...     "TASK [conf]**********\\nfatal: Some \\n multiline\\nERROR\\nNO MORE HOSTS LEFT *********"
+    ... )
+    'fatal: Some \\n multiline\\nERROR\\n'
+    """
+    err_start = log.find("fatal:")
+    if err_start > -1:
+        task_marker = log.find("******", err_start)
+        err_end = log.rfind("\n", 0, task_marker)
+        return log[err_start : err_end + 1]
+    return None
+
+
+def _run_action_and_assert_result(
+    obj: Union[Cluster, Service, Host, Component],
+    action_name: str,
+    expected_status="success",
+    **kwargs,
+):
+    """
+    Run action and assert that status equals to 'status' argument
+    """
+    with allure.step(
+        f"Perform action '{action_name}' for {obj.__class__} '{obj.name}'"
+    ), _suggest_action_if_not_exists(obj, action_name):
+        task = obj.action(name=action_name).run(**kwargs)
+        result = task.wait()
+        ansible_error = ""
+        if result != expected_status and expected_status == "success":
+            ansible_error = _get_error_text_from_task_logs(task)
+        assert_action_result(
+            name=action_name,
+            result=obj.action(name=action_name).run(**kwargs).wait(),
+            status=expected_status,
+            additional_message=ansible_error,
+        )
+
+
 def run_cluster_action_and_assert_result(
     cluster: Cluster, action: str, status="success", **kwargs
 ):
     """
     Run cluster action and assert that status equals to 'status' argument
     """
-    with allure.step(
-        f"Perform action '{action}' for cluster '{cluster.name}'"
-    ), _suggest_action_if_not_exists(cluster, action):
-        assert_action_result(
-            name=action,
-            result=cluster.action(name=action).run(**kwargs).wait(),
-            status=status,
-        )
+    _run_action_and_assert_result(
+        obj=cluster, action_name=action, expected_status=status, **kwargs
+    )
 
 
 def run_service_action_and_assert_result(
@@ -46,14 +97,9 @@ def run_service_action_and_assert_result(
     """
     Run service action and assert that status equals to 'status' argument
     """
-    with allure.step(
-        f"Perform action '{action}' for service '{service.name}'"
-    ), _suggest_action_if_not_exists(service, action):
-        assert_action_result(
-            name=action,
-            result=service.action(name=action).run(**kwargs).wait(),
-            status=status,
-        )
+    _run_action_and_assert_result(
+        obj=service, action_name=action, expected_status=status, **kwargs
+    )
 
 
 def run_component_action_and_assert_result(
@@ -62,14 +108,9 @@ def run_component_action_and_assert_result(
     """
     Run component action and assert that status equals to 'status' argument
     """
-    with allure.step(
-        f"Perform action '{action}' for component '{component.name}'"
-    ), _suggest_action_if_not_exists(component, action):
-        assert_action_result(
-            name=action,
-            result=component.action(name=action).run(**kwargs).wait(),
-            status=status,
-        )
+    _run_action_and_assert_result(
+        obj=component, action_name=action, expected_status=status, **kwargs
+    )
 
 
 def run_host_action_and_assert_result(
@@ -78,14 +119,9 @@ def run_host_action_and_assert_result(
     """
     Run host action and assert that status equals to 'status' argument
     """
-    with allure.step(
-        f"Perform action '{action}' for host '{host.fqdn}'"
-    ), _suggest_action_if_not_exists(host, action):
-        assert_action_result(
-            name=action,
-            result=host.action(name=action).run(**kwargs).wait(),
-            status=status,
-        )
+    _run_action_and_assert_result(
+        obj=host, action_name=action, expected_status=status, **kwargs
+    )
 
 
 @contextmanager

--- a/src/adcm_pytest_plugin/steps/actions.py
+++ b/src/adcm_pytest_plugin/steps/actions.py
@@ -66,7 +66,7 @@ def _run_action_and_assert_result(
     """
     obj_name = obj.name if not isinstance(obj, Host) else obj.fqdn
     with allure.step(
-        f"Perform action '{action_name}' for {obj.__class__} '{obj_name}'"
+        f"Perform action '{action_name}' for {obj.__class__.__name__} '{obj_name}'"
     ), _suggest_action_if_not_exists(obj, action_name):
         task = obj.action(name=action_name).run(**kwargs)
         result = task.wait()
@@ -75,7 +75,7 @@ def _run_action_and_assert_result(
             ansible_error = _get_error_text_from_task_logs(task)
         assert_action_result(
             name=action_name,
-            result=obj.action(name=action_name).run(**kwargs).wait(),
+            result=result,
             status=expected_status,
             additional_message=ansible_error,
         )

--- a/src/adcm_pytest_plugin/steps/actions.py
+++ b/src/adcm_pytest_plugin/steps/actions.py
@@ -50,8 +50,8 @@ def _extract_error_from_ansible_log(log: str):
     err_start = log.find("fatal:")
     if err_start > -1:
         task_marker = log.find("******", err_start)
-        err_end = log.rfind("\n", 0, task_marker)
-        return log[err_start : err_end + 1]
+        err_end = log.rfind("\n", 0, task_marker) + 1
+        return log[err_start:err_end]
     return None
 
 

--- a/src/adcm_pytest_plugin/steps/actions.py
+++ b/src/adcm_pytest_plugin/steps/actions.py
@@ -64,8 +64,9 @@ def _run_action_and_assert_result(
     """
     Run action and assert that status equals to 'status' argument
     """
+    obj_name = obj.name if not isinstance(obj, Host) else obj.fqdn
     with allure.step(
-        f"Perform action '{action_name}' for {obj.__class__} '{obj.name}'"
+        f"Perform action '{action_name}' for {obj.__class__} '{obj_name}'"
     ), _suggest_action_if_not_exists(obj, action_name):
         task = obj.action(name=action_name).run(**kwargs)
         result = task.wait()

--- a/src/adcm_pytest_plugin/steps/asserts.py
+++ b/src/adcm_pytest_plugin/steps/asserts.py
@@ -44,7 +44,7 @@ def assert_state(obj: BaseAPIObject, state):
 
 
 @allure.step("Assert action result to be equal to {status}")
-def assert_action_result(result: str, status: str, name=""):
+def assert_action_result(result: str, status: str, name="", additional_message=""):
     """
     Asserts action result to be equal to 'status' argument
 
@@ -58,9 +58,16 @@ def assert_action_result(result: str, status: str, name=""):
     Traceback (most recent call last):
     ...
     AssertionError: Action some_action finished execution with unexpected result - '200'. Expected - '400'
+    >>> assert_action_result("200", "500", additional_message="My custom message")
+    Traceback (most recent call last):
+    ...
+    AssertionError: Action  finished execution with unexpected result - '200'. Expected - '500'
+    My custom message
     """
-    assert result == status, (
-        f"Action {name} "
-        f"finished execution with unexpected result - '{result}'. "
+    message = (
+        f"Action {name} finished execution with unexpected result - '{result}'. "
         f"Expected - '{status}'"
     )
+    if additional_message:
+        message += f"\n{additional_message}"
+    assert result == status, message


### PR DESCRIPTION
We have a lot of tests that run actions and expect their result to be successful. When action fails we get a similar error message for all cases.
To overcome this issue assertion message is extended with the ansible error message from the log.