### PR TITLE
CI-854 Fix adcm init wait

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     include_package_data=True,
-    version="3.2.1",
+    version="3.2.2",
     # the following makes a plugin available to pytest
     entry_points={"pytest11": ["adcm_pytest_plugin = adcm_pytest_plugin.plugin"]},
     # custom PyPI classifier for pytest plugins

--- a/src/adcm_pytest_plugin/docker_utils.py
+++ b/src/adcm_pytest_plugin/docker_utils.py
@@ -180,6 +180,19 @@ def split_tag(image_name: str):
     return image_repo, image_tag
 
 
+def _wait_for_adcm_container_init(container, container_ip, port, timeout=120):
+    if not wait_for_url(f"http://{container_ip}:{port}/api/v1/", timeout):
+        additional_message = ""
+        try:
+            container.kill()
+        except APIError:
+            additional_message = " \nWARNING: Failed to kill docker container. Try to remove it by hand"
+        raise TimeoutError(
+            f"ADCM API has not responded in {timeout} seconds"
+            f"{additional_message}"
+        )
+
+
 class ADCM:
     """
     Class that wraps ADCM Api operation over self.api (ADCMApiWrapper)
@@ -262,21 +275,8 @@ class DockerWrapper:
             port = "8000"
         else:
             container_ip = ip
-        self._wait_for_container_init(container, container_ip, port)
+        _wait_for_adcm_container_init(container, container_ip, port)
         return ADCM(container, container_ip, port)
-
-    @staticmethod
-    def _wait_for_container_init(container, container_ip, port, timeout=120):
-        if not wait_for_url(f"http://{container_ip}:{port}/api/v1/", timeout):
-            additional_message = ""
-            try:
-                container.kill()
-            except APIError:
-                additional_message = " \nWARNING: Failed to kill docker container. Try to remove it by hand"
-            raise TimeoutError(
-                f"ADCM API has not responded in {timeout} seconds"
-                f"{additional_message}"
-            )
 
     # pylint: disable=R0913
     @allure.step("Run ADCM container from the image {image}:{tag}")

--- a/src/adcm_pytest_plugin/docker_utils.py
+++ b/src/adcm_pytest_plugin/docker_utils.py
@@ -186,10 +186,11 @@ def _wait_for_adcm_container_init(container, container_ip, port, timeout=120):
         try:
             container.kill()
         except APIError:
-            additional_message = " \nWARNING: Failed to kill docker container. Try to remove it by hand"
+            additional_message = (
+                " \nWARNING: Failed to kill docker container. Try to remove it by hand"
+            )
         raise TimeoutError(
-            f"ADCM API has not responded in {timeout} seconds"
-            f"{additional_message}"
+            f"ADCM API has not responded in {timeout} seconds{additional_message}"
         )
 
 

--- a/src/adcm_pytest_plugin/docker_utils.py
+++ b/src/adcm_pytest_plugin/docker_utils.py
@@ -267,9 +267,7 @@ class DockerWrapper:
 
     @staticmethod
     def _wait_for_container_init(container, container_ip, port, timeout=120):
-        if not wait_for_url(
-            "http://{}:{}/api/v1/".format(container_ip, port), timeout
-        ):
+        if not wait_for_url(f"http://{container_ip}:{port}/api/v1/", timeout):
             additional_message = ""
             try:
                 container.kill()

--- a/src/adcm_pytest_plugin/docker_utils.py
+++ b/src/adcm_pytest_plugin/docker_utils.py
@@ -264,7 +264,9 @@ class DockerWrapper:
             container_ip = ip
 
         init_timeout = 120
-        if not wait_for_url("http://{}:{}/api/v1/".format(container_ip, port), init_timeout):
+        if not wait_for_url(
+            "http://{}:{}/api/v1/".format(container_ip, port), init_timeout
+        ):
             raise TimeoutError(f"ADCM API has not responded in {init_timeout}")
         return ADCM(container, container_ip, port)
 

--- a/src/adcm_pytest_plugin/docker_utils.py
+++ b/src/adcm_pytest_plugin/docker_utils.py
@@ -267,6 +267,7 @@ class DockerWrapper:
         if not wait_for_url(
             "http://{}:{}/api/v1/".format(container_ip, port), init_timeout
         ):
+            container.stop()
             raise TimeoutError(f"ADCM API has not responded in {init_timeout}")
         return ADCM(container, container_ip, port)
 

--- a/src/adcm_pytest_plugin/docker_utils.py
+++ b/src/adcm_pytest_plugin/docker_utils.py
@@ -268,7 +268,7 @@ class DockerWrapper:
             "http://{}:{}/api/v1/".format(container_ip, port), init_timeout
         ):
             container.stop()
-            raise TimeoutError(f"ADCM API has not responded in {init_timeout}")
+            raise TimeoutError(f"ADCM API has not responded in {init_timeout} seconds")
         return ADCM(container, container_ip, port)
 
     # pylint: disable=R0913

--- a/src/adcm_pytest_plugin/docker_utils.py
+++ b/src/adcm_pytest_plugin/docker_utils.py
@@ -267,7 +267,7 @@ class DockerWrapper:
         if not wait_for_url(
             "http://{}:{}/api/v1/".format(container_ip, port), init_timeout
         ):
-            container.stop()
+            container.kill()
             raise TimeoutError(f"ADCM API has not responded in {init_timeout} seconds")
         return ADCM(container, container_ip, port)
 

--- a/src/adcm_pytest_plugin/docker_utils.py
+++ b/src/adcm_pytest_plugin/docker_utils.py
@@ -267,8 +267,15 @@ class DockerWrapper:
         if not wait_for_url(
             "http://{}:{}/api/v1/".format(container_ip, port), init_timeout
         ):
-            container.kill()
-            raise TimeoutError(f"ADCM API has not responded in {init_timeout} seconds")
+            additional_message = ""
+            try:
+                container.kill()
+            except APIError:
+                additional_message = " \nWARNING: Failed to kill docker container. Try to remove it by hand"
+            raise TimeoutError(
+                f"ADCM API has not responded in {init_timeout} seconds"
+                f"{additional_message}"
+            )
         return ADCM(container, container_ip, port)
 
     # pylint: disable=R0913

--- a/src/adcm_pytest_plugin/docker_utils.py
+++ b/src/adcm_pytest_plugin/docker_utils.py
@@ -263,7 +263,9 @@ class DockerWrapper:
         else:
             container_ip = ip
 
-        wait_for_url("http://{}:{}/api/v1/".format(container_ip, port), 60)
+        init_timeout = 120
+        if not wait_for_url("http://{}:{}/api/v1/".format(container_ip, port), init_timeout):
+            raise TimeoutError(f"ADCM API has not responded in {init_timeout}")
         return ADCM(container, container_ip, port)
 
     # pylint: disable=R0913

--- a/src/adcm_pytest_plugin/docker_utils.py
+++ b/src/adcm_pytest_plugin/docker_utils.py
@@ -262,10 +262,13 @@ class DockerWrapper:
             port = "8000"
         else:
             container_ip = ip
+        self._wait_for_container_init(container, container_ip, port)
+        return ADCM(container, container_ip, port)
 
-        init_timeout = 120
+    @staticmethod
+    def _wait_for_container_init(container, container_ip, port, timeout=120):
         if not wait_for_url(
-            "http://{}:{}/api/v1/".format(container_ip, port), init_timeout
+            "http://{}:{}/api/v1/".format(container_ip, port), timeout
         ):
             additional_message = ""
             try:
@@ -273,10 +276,9 @@ class DockerWrapper:
             except APIError:
                 additional_message = " \nWARNING: Failed to kill docker container. Try to remove it by hand"
             raise TimeoutError(
-                f"ADCM API has not responded in {init_timeout} seconds"
+                f"ADCM API has not responded in {timeout} seconds"
                 f"{additional_message}"
             )
-        return ADCM(container, container_ip, port)
 
     # pylint: disable=R0913
     @allure.step("Run ADCM container from the image {image}:{tag}")

--- a/src/adcm_pytest_plugin/fixtures.py
+++ b/src/adcm_pytest_plugin/fixtures.py
@@ -106,8 +106,6 @@ def image(request, cmd_opts):
     elif cmd_opts.adcm_image:
         params["adcm_repo"], params["adcm_tag"] = split_tag(cmd_opts.adcm_image)
 
-    init_image = get_initialized_adcm_image(pull=pull, dc=dc, **params)
-
     if not (cmd_opts.dontstop or cmd_opts.staticimage):
 
         def fin():
@@ -123,6 +121,8 @@ def image(request, cmd_opts):
             )
 
         request.addfinalizer(fin)
+
+    init_image = get_initialized_adcm_image(pull=pull, dc=dc, **params)
 
     return init_image["repo"], init_image["tag"]
 


### PR DESCRIPTION
There was a problem with ADCM initialization. Now we will wait for ADCM API response up to 120 seconds at the init stage and raise if ADCM has not responded.