### PR TITLE
Fix test and error collection

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     include_package_data=True,
-    version="3.3.4",
+    version="3.3.5",
     # the following makes a plugin available to pytest
     entry_points={"pytest11": ["adcm_pytest_plugin = adcm_pytest_plugin.plugin"]},
     # custom PyPI classifier for pytest plugins
@@ -32,6 +32,7 @@ setup(
         "ifaddr",
         "retry",
         "deprecated",
+        "coreapi",
     ],
     classifiers=["Framework :: Pytest"],
 )

--- a/src/adcm_pytest_plugin/steps/actions.py
+++ b/src/adcm_pytest_plugin/steps/actions.py
@@ -16,6 +16,7 @@ Common test steps with actions
 from contextlib import contextmanager
 from difflib import get_close_matches
 from typing import Union
+from coreapi.exceptions import ErrorMessage
 
 import allure
 from adcm_client.base import ObjectNotFound
@@ -31,9 +32,12 @@ def _get_error_text_from_task_logs(task: Task):
             for log in job.log_list():
                 if log.type == "stdout":
                     error_text += _extract_error_from_ansible_log(log.content)
-        except ObjectNotFound:
+        except ErrorMessage as log_exception:
             # Multijobs has no logs for parent Job
-            pass
+            if log_exception.error._data["code"] == "LOG_NOT_FOUND":
+                pass
+            else:
+                raise log_exception
     return error_text
 
 

--- a/src/adcm_pytest_plugin/steps/actions.py
+++ b/src/adcm_pytest_plugin/steps/actions.py
@@ -34,6 +34,7 @@ def _get_error_text_from_task_logs(task: Task):
                     error_text += _extract_error_from_ansible_log(log.content)
         except ErrorMessage as log_exception:
             # Multijobs has no logs for parent Job
+            # pylint: disable=protected-access
             if log_exception.error._data["code"] == "LOG_NOT_FOUND":
                 pass
             else:

--- a/tests/plugin/test_steps_data/fail_multijob_cluster/config.yaml
+++ b/tests/plugin/test_steps_data/fail_multijob_cluster/config.yaml
@@ -17,13 +17,13 @@
     fail_action:
       type: task
       scripts:
-        - name: pass
-          display_name: Pass
-          script_type: ansible
-          script: pass_action.yaml
         - name: fail
           display_name: Fail
           script_type: ansible
           script: fail_action.yaml
+        - name: pass
+          display_name: Pass
+          script_type: ansible
+          script: pass_action.yaml
       states:
         available: any


### PR DESCRIPTION
There is a problem with adcm_client. It raises generic coreapi error instead of dedicated Object not found when a job has no log files.
This PR aimed to fit coreapi exception.
Also, the func test was fixed. In the previous version, there were no jobs without logs. Now we have a skipped job without logs so the test is relevant now.