### PR TITLE
Fix issue with image fixture finalizer

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     include_package_data=True,
-    version="3.3.7",
+    version="3.3.8",
     # the following makes a plugin available to pytest
     entry_points={"pytest11": ["adcm_pytest_plugin = adcm_pytest_plugin.plugin"]},
     # custom PyPI classifier for pytest plugins

--- a/src/adcm_pytest_plugin/fixtures.py
+++ b/src/adcm_pytest_plugin/fixtures.py
@@ -118,8 +118,12 @@ def image(request, cmd_opts):
                         # https://github.com/docker/docker-py/issues/1966 workaround
                         pass
                 retry_call(
-                    dc.images.remove, fargs=[image_name], fkwargs={"force": True}, tries=5
+                    dc.images.remove,
+                    fargs=[image_name],
+                    fkwargs={"force": True},
+                    tries=5,
                 )
+
         # Set None for init image to avoid errors in finalizer
         # when get_initialized_adcm_image() fails
         init_image = None

--- a/src/adcm_pytest_plugin/fixtures.py
+++ b/src/adcm_pytest_plugin/fixtures.py
@@ -109,17 +109,20 @@ def image(request, cmd_opts):
     if not (cmd_opts.dontstop or cmd_opts.staticimage):
 
         def fin():
-            image_name = "{}:{}".format(*init_image.values())
-            for container in dc.containers.list(filters=dict(ancestor=image_name)):
-                try:
-                    container.wait(condition="removed", timeout=30)
-                except ConnectionError:
-                    # https://github.com/docker/docker-py/issues/1966 workaround
-                    pass
-            retry_call(
-                dc.images.remove, fargs=[image_name], fkwargs={"force": True}, tries=5
-            )
-
+            if init_image:
+                image_name = "{}:{}".format(*init_image.values())
+                for container in dc.containers.list(filters=dict(ancestor=image_name)):
+                    try:
+                        container.wait(condition="removed", timeout=30)
+                    except ConnectionError:
+                        # https://github.com/docker/docker-py/issues/1966 workaround
+                        pass
+                retry_call(
+                    dc.images.remove, fargs=[image_name], fkwargs={"force": True}, tries=5
+                )
+        # Set None for init image to avoid errors in finalizer
+        # when get_initialized_adcm_image() fails
+        init_image = None
         request.addfinalizer(fin)
 
     init_image = get_initialized_adcm_image(pull=pull, dc=dc, **params)


### PR DESCRIPTION
Previously when get_initialized_adcm_image() function fails
before returning any values there was an error
"variable referenced before assignment"
This commit is aimed to fix this issue