### PR TITLE
Set env vars for test results

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     include_package_data=True,
-    version="3.3.8",
+    version="3.3.9",
     # the following makes a plugin available to pytest
     entry_points={"pytest11": ["adcm_pytest_plugin = adcm_pytest_plugin.plugin"]},
     # custom PyPI classifier for pytest plugins

--- a/src/adcm_pytest_plugin/docker_utils.py
+++ b/src/adcm_pytest_plugin/docker_utils.py
@@ -108,8 +108,8 @@ def get_file_from_container(instance, path, filename):
     for i in stream:
         file_obj.write(i)
     file_obj.seek(0)
-    tar = tarfile.open(mode="r", fileobj=file_obj)
-    return tar.extractfile(filename)
+    with tarfile.open(mode="r", fileobj=file_obj) as tar:
+        return tar.extractfile(filename)
 
 
 @allure.step("Prepare initialized ADCM image")

--- a/src/adcm_pytest_plugin/plugin.py
+++ b/src/adcm_pytest_plugin/plugin.py
@@ -11,6 +11,7 @@
 # limitations under the License.
 
 # pylint: disable=W0611, W0401, W0614
+import os
 from argparse import Namespace
 
 import pytest
@@ -160,4 +161,14 @@ def pytest_runtest_makereport(item, call):
     # set a report attribute for each phase of a call, which can
     # be "setup", "call", "teardown"
 
+    os.environ["rep_" + rep.when + "_passed"] = str(rep.passed)
     setattr(item, "rep_" + rep.when, rep)
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """
+    Clear custom env variables at the end of all tests
+    """
+    for var in dict(os.environ):
+        if "rep_" in var:
+            del os.environ[var]


### PR DESCRIPTION
There is a case when we need to have information about test result in runtime.
For fixtures we can get it from request.
In other non-fixtures methods env looks like nice option to get this information