### PR TITLE
Add bundle pre-upload

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     include_package_data=True,
-    version="3.4.0",
+    version="4.0.0",
     # the following makes a plugin available to pytest
     entry_points={"pytest11": ["adcm_pytest_plugin = adcm_pytest_plugin.plugin"]},
     # custom PyPI classifier for pytest plugins

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="adcm_pytest_plugin",
-    description="The pytest plugin which includes a set of common tools for ADCM testing",
+    description="The pytest plugin including a set of common tools for ADCM testing",
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     include_package_data=True,

--- a/src/adcm_pytest_plugin/docker_utils.py
+++ b/src/adcm_pytest_plugin/docker_utils.py
@@ -130,15 +130,15 @@ class ADCMInitializer:
     )
 
     def __init__(
-            self,
-            repo="local/adcminit",
-            tag=None,
-            adcm_repo=None,
-            adcm_tag=None,
-            pull=True,
-            dc=None,
-            preupload_bundle_urls=None,
-            adcm_credentials=None,
+        self,
+        repo="local/adcminit",
+        tag=None,
+        adcm_repo=None,
+        adcm_tag=None,
+        pull=True,
+        dc=None,
+        preupload_bundle_urls=None,
+        adcm_credentials=None,
     ):
         self.repo = repo
         self.tag = tag if tag else random_string()
@@ -182,7 +182,9 @@ class ADCMInitializer:
         self._preupload_bundles()
         # Create a snapshot from initialized container
         self._adcm.container.stop()
-        with allure.step(f"Commit initialized ADCM container to image {self.repo}:{self.tag}"):
+        with allure.step(
+            f"Commit initialized ADCM container to image {self.repo}:{self.tag}"
+        ):
             self._adcm.container.commit(repository=self.repo, tag=self.tag)
         self._adcm.container.remove()
         return {"repo": self.repo, "tag": self.tag}

--- a/src/adcm_pytest_plugin/docker_utils.py
+++ b/src/adcm_pytest_plugin/docker_utils.py
@@ -218,18 +218,18 @@ class ADCMInitializer:
         self._adcm.container.remove()
         return {"repo": self.repo, "tag": self.tag}
 
-    @allure.step("Pre-upload bundles into ADCM before image initialization")
     def _preupload_bundles(self):
         if self.preupload_bundle_urls:
-            adcm_cli = ADCMClient(url=self._adcm.url, **self.adcm_api_credentials)
-            for url in self.preupload_bundle_urls:
-                try:
-                    adcm_cli.upload_from_url(url=url)
-                except ErrorMessage as exception:
-                    # skip error only if bundle was already uploaded before
-                    # can occur in case of --staticimage use
-                    if "BUNDLE_ERROR" not in exception.error:
-                        raise exception
+            with allure.step("Pre-upload bundles into ADCM before image initialization"):
+                adcm_cli = ADCMClient(url=self._adcm.url, **self.adcm_api_credentials)
+                for url in self.preupload_bundle_urls:
+                    try:
+                        adcm_cli.upload_from_url(url)
+                    except ErrorMessage as exception:
+                        # skip error only if bundle was already uploaded before
+                        # can occur in case of --staticimage use
+                        if "BUNDLE_ERROR" not in exception.error:
+                            raise exception
 
 
 def image_exists(repo, tag, dc=None):

--- a/src/adcm_pytest_plugin/docker_utils.py
+++ b/src/adcm_pytest_plugin/docker_utils.py
@@ -112,6 +112,7 @@ def get_file_from_container(instance, path, filename):
         return tar.extractfile(filename)
 
 
+# pylint: disable=too-many-instance-attributes
 class ADCMInitializer:
     """
     Class for initialized ADCM image preparation.
@@ -129,6 +130,7 @@ class ADCMInitializer:
         "_adcm",
     )
 
+    # pylint: disable=too-many-arguments
     def __init__(
         self,
         repo="local/adcminit",

--- a/src/adcm_pytest_plugin/docker_utils.py
+++ b/src/adcm_pytest_plugin/docker_utils.py
@@ -220,7 +220,9 @@ class ADCMInitializer:
 
     def _preupload_bundles(self):
         if self.preupload_bundle_urls:
-            with allure.step("Pre-upload bundles into ADCM before image initialization"):
+            with allure.step(
+                "Pre-upload bundles into ADCM before image initialization"
+            ):
                 adcm_cli = ADCMClient(url=self._adcm.url, **self.adcm_api_credentials)
                 for url in self.preupload_bundle_urls:
                     try:

--- a/src/adcm_pytest_plugin/docker_utils.py
+++ b/src/adcm_pytest_plugin/docker_utils.py
@@ -23,6 +23,7 @@ import allure
 import docker
 import tarfile
 
+from adcm_client.wrappers.api import ADCMApiWrapper
 from docker.errors import APIError, ImageNotFound
 from adcm_client.util.wait import wait_for_url
 from adcm_client.objects import ADCMClient
@@ -280,13 +281,14 @@ class ADCM:
     and wraps docker over self.container (see docker module for info)
     """
 
-    __slots__ = ("container", "ip", "port", "url")
+    __slots__ = ("container", "ip", "port", "url", "api")
 
     def __init__(self, container, ip, port):
         self.container = container
         self.ip = ip
         self.port = port
         self.url = "http://{}:{}".format(self.ip, self.port)
+        self.api = ADCMApiWrapper(self.url)
 
     def stop(self):
         """Stops container"""

--- a/src/adcm_pytest_plugin/docker_utils.py
+++ b/src/adcm_pytest_plugin/docker_utils.py
@@ -125,7 +125,7 @@ class ADCMInitializer:
         "pull",
         "dc",
         "preupload_bundle_urls",
-        "adcm_credentials",
+        "adcm_api_credentials",
         "_adcm",
     )
 
@@ -138,7 +138,7 @@ class ADCMInitializer:
         pull=True,
         dc=None,
         preupload_bundle_urls=None,
-        adcm_credentials=None,
+        adcm_api_credentials=None,
     ):
         self.repo = repo
         self.tag = tag if tag else random_string()
@@ -147,7 +147,7 @@ class ADCMInitializer:
         self.pull = pull
         self.dc = dc if dc else docker.from_env(timeout=120)
         self.preupload_bundle_urls = preupload_bundle_urls
-        self.adcm_credentials = adcm_credentials if adcm_credentials else {}
+        self.adcm_api_credentials = adcm_api_credentials if adcm_api_credentials else {}
         self._adcm = None
 
     @allure.step("Prepare initialized ADCM image")
@@ -192,7 +192,7 @@ class ADCMInitializer:
     @allure.step("Pre-upload bundles into ADCM before image initialization")
     def _preupload_bundles(self):
         if self.preupload_bundle_urls:
-            adcm_cli = ADCMClient(url=self._adcm.url, **self.adcm_credentials)
+            adcm_cli = ADCMClient(url=self._adcm.url, **self.adcm_api_credentials)
             for url in self.preupload_bundle_urls:
                 adcm_cli.upload_from_url(url=url)
 

--- a/src/adcm_pytest_plugin/fixtures.py
+++ b/src/adcm_pytest_plugin/fixtures.py
@@ -50,13 +50,13 @@ __all__ = [
     "sdk_client_ms",
     "sdk_client_fs",
     "sdk_client_ss",
-    "adcm_credentials",
+    "adcm_api_credentials",
 ]
 
 
 @allure.title("ADCM credentials")
 @pytest.fixture(scope="session")
-def adcm_credentials() -> dict:
+def adcm_api_credentials() -> dict:
     """ADCM credentials for use in tests"""
     return {"user": "admin", "password": "admin"}
 
@@ -64,7 +64,7 @@ def adcm_credentials() -> dict:
 # pylint: disable=W0621
 @allure.title("ADCM Image")
 @pytest.fixture(scope="session")
-def image(request, cmd_opts, adcm_credentials):
+def image(request, cmd_opts, adcm_api_credentials):
     """That fixture creates ADCM container, waits until
     a database becomes initialised and stores that as images
     with random tag and name local/adcminit
@@ -142,7 +142,7 @@ def image(request, cmd_opts, adcm_credentials):
         pull=pull,
         dc=dc,
         preupload_bundle_urls=_get_bundle_urls_for_preupload(cmd_opts),
-        adcm_credentials=adcm_credentials,
+        adcm_api_credentials=adcm_api_credentials,
         **params,
     ).get_initialized_adcm_image()
 
@@ -170,7 +170,7 @@ def _get_bundle_urls_for_preupload(cmd_opts):
     return preupload_bundle_urls
 
 
-def _adcm(image, cmd_opts, request, adcm_credentials) -> ADCM:
+def _adcm(image, cmd_opts, request, adcm_api_credentials) -> ADCM:
     repo, tag = image
     if cmd_opts.remote_docker:
         dw = DockerWrapper(base_url=f"tcp://{cmd_opts.remote_docker}")
@@ -230,7 +230,7 @@ def _adcm(image, cmd_opts, request, adcm_credentials) -> ADCM:
                                 extension="tgz",
                             )
 
-            _remove_hosts(ADCMClient(url=adcm.url, **adcm_credentials))
+            _remove_hosts(ADCMClient(url=adcm.url, **adcm_api_credentials))
 
             try:
                 adcm.container.kill()
@@ -323,53 +323,53 @@ def client(adcm):
 ##################################################
 @allure.title("[MS] ADCM Container")
 @pytest.fixture(scope="module")
-def adcm_ms(image, cmd_opts, request, adcm_credentials) -> ADCM:
+def adcm_ms(image, cmd_opts, request, adcm_api_credentials) -> ADCM:
     """Runs adcm container from the previously initialized image.
     Operates '--dontstop' option.
     Returns authorized instance of ADCM object
     """
-    return _adcm(image, cmd_opts, request, adcm_credentials)
+    return _adcm(image, cmd_opts, request, adcm_api_credentials)
 
 
 @allure.title("[FS] ADCM Container")
 @pytest.fixture(scope="function")
-def adcm_fs(image, cmd_opts, request, adcm_credentials) -> ADCM:
+def adcm_fs(image, cmd_opts, request, adcm_api_credentials) -> ADCM:
     """Runs adcm container from the previously initialized image.
     Operates '--dontstop' option.
     Returns authorized instance of ADCM object
     """
-    return _adcm(image, cmd_opts, request, adcm_credentials)
+    return _adcm(image, cmd_opts, request, adcm_api_credentials)
 
 
 @allure.title("[SS] ADCM Container")
 @pytest.fixture(scope="session")
-def adcm_ss(image, cmd_opts, request, adcm_credentials) -> ADCM:
+def adcm_ss(image, cmd_opts, request, adcm_api_credentials) -> ADCM:
     """Runs adcm container from the previously initialized image.
     Operates '--dontstop' option.
     Returns authorized instance of ADCM object
     """
-    return _adcm(image, cmd_opts, request, adcm_credentials)
+    return _adcm(image, cmd_opts, request, adcm_api_credentials)
 
 
 @allure.title("[MS] ADCM Client")
 @pytest.fixture(scope="module")
-def sdk_client_ms(adcm_ms: ADCM, adcm_credentials) -> ADCMClient:
+def sdk_client_ms(adcm_ms: ADCM, adcm_api_credentials) -> ADCMClient:
     """Returns ADCMClient object from adcm_client"""
-    return ADCMClient(url=adcm_ms.url, **adcm_credentials)
+    return ADCMClient(url=adcm_ms.url, **adcm_api_credentials)
 
 
 @allure.title("[FS] ADCM Client")
 @pytest.fixture(scope="function")
-def sdk_client_fs(adcm_fs: ADCM, adcm_credentials) -> ADCMClient:
+def sdk_client_fs(adcm_fs: ADCM, adcm_api_credentials) -> ADCMClient:
     """Returns ADCMClient object from adcm_client"""
-    return ADCMClient(url=adcm_fs.url, **adcm_credentials)
+    return ADCMClient(url=adcm_fs.url, **adcm_api_credentials)
 
 
 @allure.title("[SS] ADCM Client")
 @pytest.fixture(scope="session")
-def sdk_client_ss(adcm_ss: ADCM, adcm_credentials) -> ADCMClient:
+def sdk_client_ss(adcm_ss: ADCM, adcm_api_credentials) -> ADCMClient:
     """Returns ADCMClient object from adcm_client"""
-    return ADCMClient(url=adcm_ss.url, **adcm_credentials)
+    return ADCMClient(url=adcm_ss.url, **adcm_api_credentials)
 
 
 @allure.title("Pytest options")

--- a/src/adcm_pytest_plugin/fixtures.py
+++ b/src/adcm_pytest_plugin/fixtures.py
@@ -138,33 +138,11 @@ def image(request, cmd_opts, adcm_api_credentials):
     init_image = ADCMInitializer(
         pull=pull,
         dc=dc,
-        preupload_bundle_urls=_get_bundle_urls_for_preupload(cmd_opts),
         adcm_api_credentials=adcm_api_credentials,
         **params,
     ).get_initialized_adcm_image()
 
     return init_image["repo"], init_image["tag"]
-
-
-def _get_bundle_urls_for_preupload(cmd_opts):
-    """
-    Analyze cmd_opts to define bundles that should be pre-uploaded
-    into ADCM at the start of the test session.
-    """
-    preupload_bundle_urls = []
-    if hasattr(cmd_opts, "cloud") and cmd_opts.cloud:
-        try:
-            preupload_bundle_urls.append(
-                "https://ci.arenadata.io/artifactory/list/adcm_bundles/"
-                f"adcm_host_{cmd_opts.cloud}_v{cmd_opts.host_version}_{cmd_opts.host_edition}.tgz"
-            )
-        except AttributeError:
-            warnings.warn(
-                "Option --cloud should be used with --host-version and --host_edition! "
-                "See https://github.com/arenadata/adcm_pytest_tools for details"
-            )
-
-    return preupload_bundle_urls
 
 
 def _adcm(image, cmd_opts, request, adcm_api_credentials) -> ADCM:

--- a/src/adcm_pytest_plugin/fixtures.py
+++ b/src/adcm_pytest_plugin/fixtures.py
@@ -56,7 +56,7 @@ __all__ = [
 @allure.title("ADCM credentials")
 @pytest.fixture(scope="session")
 def adcm_credentials():
-    """ ADCM credentials for use in tests"""
+    """ADCM credentials for use in tests"""
     return {"user": "admin", "password": "admin"}
 
 

--- a/src/adcm_pytest_plugin/fixtures.py
+++ b/src/adcm_pytest_plugin/fixtures.py
@@ -50,6 +50,7 @@ __all__ = [
     "sdk_client_ms",
     "sdk_client_fs",
     "sdk_client_ss",
+    "adcm_credentials",
 ]
 
 

--- a/src/adcm_pytest_plugin/fixtures.py
+++ b/src/adcm_pytest_plugin/fixtures.py
@@ -56,7 +56,7 @@ __all__ = [
 
 @allure.title("ADCM credentials")
 @pytest.fixture(scope="session")
-def adcm_credentials():
+def adcm_credentials() -> dict:
     """ADCM credentials for use in tests"""
     return {"user": "admin", "password": "admin"}
 

--- a/src/adcm_pytest_plugin/fixtures.py
+++ b/src/adcm_pytest_plugin/fixtures.py
@@ -161,8 +161,10 @@ def _get_bundle_urls_for_preupload(cmd_opts):
                 f"adcm_host_{cmd_opts.cloud}_v{cmd_opts.host_version}_{cmd_opts.host_edition}.tgz"
             )
         except AttributeError:
-            warnings.warn("Option --cloud should be used with --host-version and --host_edition! "
-                          "See https://github.com/arenadata/adcm_pytest_tools for details")
+            warnings.warn(
+                "Option --cloud should be used with --host-version and --host_edition! "
+                "See https://github.com/arenadata/adcm_pytest_tools for details"
+            )
 
     return preupload_bundle_urls
 

--- a/src/adcm_pytest_plugin/fixtures.py
+++ b/src/adcm_pytest_plugin/fixtures.py
@@ -27,7 +27,6 @@ from allure_commons.utils import uuid4
 from allure_pytest.listener import AllureListener
 from requests.exceptions import ReadTimeout as DockerReadTimeout
 from retry.api import retry_call
-from deprecated import deprecated
 
 from .docker_utils import (
     ADCM,
@@ -42,8 +41,6 @@ from .utils import check_mutually_exclusive, remove_host
 __all__ = [
     "image",
     "cmd_opts",
-    "adcm",
-    "client",
     "adcm_fs",
     "adcm_ss",
     "adcm_ms",

--- a/src/adcm_pytest_plugin/fixtures.py
+++ b/src/adcm_pytest_plugin/fixtures.py
@@ -11,7 +11,6 @@
 # limitations under the License.
 
 import time
-import warnings
 from typing import Optional
 
 import allure

--- a/src/adcm_pytest_plugin/fixtures.py
+++ b/src/adcm_pytest_plugin/fixtures.py
@@ -26,6 +26,7 @@ from allure_commons.utils import uuid4
 from allure_pytest.listener import AllureListener
 from requests.exceptions import ReadTimeout as DockerReadTimeout
 from retry.api import retry_call
+from docker import DockerClient
 
 from .docker_utils import (
     ADCM,
@@ -115,20 +116,7 @@ def image(request, cmd_opts, adcm_api_credentials):
 
         def finalize():
             if init_image:
-                image_name = "{}:{}".format(*init_image.values())
-                for container in dc.containers.list(filters=dict(ancestor=image_name)):
-                    try:
-                        container.wait(condition="removed", timeout=30)
-                    except ConnectionError:
-                        # https://github.com/docker/docker-py/issues/1966 workaround
-                        pass
-                retry_call(
-                    dc.images.remove,
-                    fargs=[image_name],
-                    fkwargs={"force": True},
-                    tries=5,
-                )
-
+                remove_docker_image(**init_image, dc=dc)
         # Set None for init image to avoid errors in finalizer
         # when get_initialized_adcm_image() fails
         init_image = None
@@ -142,6 +130,23 @@ def image(request, cmd_opts, adcm_api_credentials):
     ).get_initialized_adcm_image()
 
     return init_image["repo"], init_image["tag"]
+
+
+def remove_docker_image(repo: str, tag: str, dc: DockerClient):
+    """Remove docker image"""
+    image_name = f"{repo}:{tag}"
+    for container in dc.containers.list(filters=dict(ancestor=image_name)):
+        try:
+            container.wait(condition="removed", timeout=30)
+        except ConnectionError:
+            # https://github.com/docker/docker-py/issues/1966 workaround
+            pass
+    retry_call(
+        dc.images.remove,
+        fargs=[image_name],
+        fkwargs={"force": True},
+        tries=5,
+    )
 
 
 def _adcm(image, cmd_opts, request, adcm_api_credentials) -> ADCM:

--- a/src/adcm_pytest_plugin/fixtures.py
+++ b/src/adcm_pytest_plugin/fixtures.py
@@ -302,22 +302,6 @@ def _remove_hosts(adcm_cli: ADCMClient):
                 pass
 
 
-# Legacy fixture should not be used in new tests!
-@deprecated
-@pytest.fixture(scope="module")
-def adcm(image, cmd_opts, request):
-    """Legacy ADCM object fixture. Do not use in new tests"""
-    return _adcm(image, cmd_opts, request)
-
-
-# Legacy fixture should not be used in new tests!
-@deprecated
-@pytest.fixture(scope="module")
-def client(adcm):
-    """Legacy api object fixture. Do not use in new tests"""
-    return adcm.api.objects
-
-
 ##################################################
 #                  S D K
 ##################################################

--- a/tests/plugin/common.py
+++ b/tests/plugin/common.py
@@ -2,6 +2,7 @@
 
 import allure
 
+
 def run_tests(
     testdir,
     filename: str = None,
@@ -27,8 +28,11 @@ def run_tests(
     opts = ["-s", "-v", *additional_opts]
     with allure.step(f"Run test {filename}"):
         result = testdir.runpytest(*opts)
-        allure.attach('\n'.join(result.outlines), name='Internal test output',
-                      attachment_type=allure.attachment_type.TEXT)
+        allure.attach(
+            "\n".join(result.outlines),
+            name="Internal test output",
+            attachment_type=allure.attachment_type.TEXT,
+        )
         if outcomes:
             result.assert_outcomes(**outcomes)
         else:

--- a/tests/plugin/common.py
+++ b/tests/plugin/common.py
@@ -1,5 +1,6 @@
 """Common methods for plugin tests"""
 
+import allure
 
 def run_tests(
     testdir,
@@ -24,9 +25,12 @@ def run_tests(
         testdir.makepyfile(py_file)
 
     opts = ["-s", "-v", *additional_opts]
-    result = testdir.runpytest(*opts)
-    if outcomes:
-        result.assert_outcomes(**outcomes)
-    else:
-        result.assert_outcomes(passed=1)
-    return result
+    with allure.step(f"Run test {filename}"):
+        result = testdir.runpytest(*opts)
+        allure.attach('\n'.join(result.outlines), name='Internal test output',
+                      attachment_type=allure.attachment_type.TEXT)
+        if outcomes:
+            result.assert_outcomes(**outcomes)
+        else:
+            result.assert_outcomes(passed=1)
+        return result


### PR DESCRIPTION
Add ADCMInitializer class for ADCM image init operations and add preupload_bundle_urls option to allow pre-upload of bundles into ADCM before committing image

Refactor ADCM API Auth and ADCMClient creation

Remove deprecated fixtures

Add tests output to allure for plugin tests