### PR TITLE
Add --verbose-actions option

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ List of available options:
 - Misc
     - [`--remote-executor-host`](#--remote-executor-host)
     - [`--remote-docker`](#--remote-docker)
+    - [`--verbose-actions`](#--verbose-actions)
 
 ---
 
@@ -267,6 +268,19 @@ Property | Value
 value | `string of host:port format`
 default | `none`
 example | `--remote-docker '10.92.7.14:2375'`
+
+#### `--verbose-actions`
+
+> If passed then ADCM actions will be started with 'verbose' checkbox selected.
+> Applied only to action calls over adcm_client. 
+> Does not affect UI action calls in tests.
+
+
+Property | Value
+---: | ---
+value | `none`
+default | `false`
+
 
 ## Writing tests for plugin
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     include_package_data=True,
-    version="4.0.3",
+    version="4.1.0",
     # the following makes a plugin available to pytest
     entry_points={"pytest11": ["adcm_pytest_plugin = adcm_pytest_plugin.plugin"]},
     # custom PyPI classifier for pytest plugins

--- a/src/adcm_pytest_plugin/plugin.py
+++ b/src/adcm_pytest_plugin/plugin.py
@@ -104,6 +104,15 @@ def pytest_addoption(parser):
         "Ex: '192.168.1.1:2375'",
     )
 
+    parser.addoption(
+        "--verbose-actions",
+        action="store_true",
+        default=False,
+        help="Run actions with 'verbose' checkbox selected. "
+        "Applied only to action calls over adcm_client."
+        "Does not affect UI action calls in tests",
+    )
+
 
 def pytest_generate_tests(metafunc):
     """

--- a/src/adcm_pytest_plugin/steps/actions.py
+++ b/src/adcm_pytest_plugin/steps/actions.py
@@ -23,6 +23,7 @@ from adcm_client.base import ObjectNotFound
 from adcm_client.objects import Cluster, Service, Host, Task, Component, Provider
 
 from .asserts import assert_action_result
+from ..plugin import options
 
 
 def _get_error_text_from_task_logs(task: Task):
@@ -79,7 +80,11 @@ def _run_action_and_assert_result(
     with allure.step(
         f"Perform action '{action_name}' for {obj.__class__.__name__} '{obj_name}'"
     ), _suggest_action_if_not_exists(obj, action_name):
-        task = obj.action(name=action_name).run(**kwargs)
+        if "verbose" in kwargs:
+            verbose = kwargs.pop("verbose")
+        else:
+            verbose = options.verbose_actions
+        task = obj.action(name=action_name).run(verbose=verbose, **kwargs)
         wait_for_task_and_assert_result(
             task=task, action_name=action_name, status=expected_status, timeout=timeout
         )

--- a/src/adcm_pytest_plugin/steps/actions.py
+++ b/src/adcm_pytest_plugin/steps/actions.py
@@ -81,12 +81,12 @@ def _run_action_and_assert_result(
     with allure.step(
         f"Perform action '{action_name}' for {obj.__class__.__name__} '{obj_name}'"
     ), _suggest_action_if_not_exists(obj, action_name):
-        if rpm.compare_versions(obj.adcm_version, "2021.02.04.13") >= 0:
-            if "verbose" in kwargs:
-                verbose = kwargs.pop("verbose")
-            else:
-                verbose = options.verbose_actions
-        task = obj.action(name=action_name).run(verbose=verbose, **kwargs)
+        if (
+            rpm.compare_versions(obj.adcm_version, "2021.02.04.13") >= 0
+            and "verbose" not in kwargs
+        ):
+            kwargs["verbose"] = options.verbose_actions
+        task = obj.action(name=action_name).run(**kwargs)
         wait_for_task_and_assert_result(
             task=task, action_name=action_name, status=expected_status, timeout=timeout
         )

--- a/src/adcm_pytest_plugin/steps/actions.py
+++ b/src/adcm_pytest_plugin/steps/actions.py
@@ -19,6 +19,7 @@ from typing import Union
 from coreapi.exceptions import ErrorMessage
 
 import allure
+from version_utils import rpm
 from adcm_client.base import ObjectNotFound
 from adcm_client.objects import Cluster, Service, Host, Task, Component, Provider
 
@@ -80,10 +81,11 @@ def _run_action_and_assert_result(
     with allure.step(
         f"Perform action '{action_name}' for {obj.__class__.__name__} '{obj_name}'"
     ), _suggest_action_if_not_exists(obj, action_name):
-        if "verbose" in kwargs:
-            verbose = kwargs.pop("verbose")
-        else:
-            verbose = options.verbose_actions
+        if rpm.compare_versions(obj.adcm_version, "2021.02.04.13") >= 0:
+            if "verbose" in kwargs:
+                verbose = kwargs.pop("verbose")
+            else:
+                verbose = options.verbose_actions
         task = obj.action(name=action_name).run(verbose=verbose, **kwargs)
         wait_for_task_and_assert_result(
             task=task, action_name=action_name, status=expected_status, timeout=timeout

--- a/tests/plugin/test_steps.py
+++ b/tests/plugin/test_steps.py
@@ -19,6 +19,7 @@ import pytest
 
 from adcm_pytest_plugin.steps.actions import run_cluster_action_and_assert_result
 from adcm_pytest_plugin.utils import get_data_dir
+from adcm_pytest_plugin.plugin import options
 
 pytestmark = [allure.suite("Plugin steps")]
 
@@ -34,3 +35,37 @@ def test_fail_action(sdk_client_fs, bundle_dir):
     assert "Meant to fail" in str(
         action_run_exception.value
     ), "No ansible error in AssertionError message"
+
+
+@pytest.mark.parametrize("bundle_dir", ["simple_action_cluster"])
+def test_verbose_actions_option(sdk_client_fs, bundle_dir):
+    """
+    Test verbose_actions option
+    Assert attr presence
+    Assert attr type
+    Assert verbose state in action logs
+    """
+    bundle_dir_full = get_data_dir(__file__, bundle_dir)
+    bundle = sdk_client_fs.upload_from_fs(bundle_dir_full)
+    cluster = bundle.cluster_create("test_cluster")
+    assert hasattr(options, "verbose_actions")
+    assert isinstance(options.verbose_actions, bool)
+    options.verbose_actions = True
+    run_cluster_action_and_assert_result(cluster=cluster, action="simple_action")
+    assert "verbosity: 4" in sdk_client_fs.job_list()[0].log_list()[0].content
+
+
+@pytest.mark.parametrize("bundle_dir", ["simple_action_cluster"])
+def test_verbose_actions_option_with_custom_verbose(sdk_client_fs, bundle_dir):
+    """
+    Test that custom verbose param for action
+    has higher priority then verbose_actions option
+    """
+    bundle_dir_full = get_data_dir(__file__, bundle_dir)
+    bundle = sdk_client_fs.upload_from_fs(bundle_dir_full)
+    cluster = bundle.cluster_create("test_cluster")
+    options.verbose_actions = True
+    run_cluster_action_and_assert_result(
+        cluster=cluster, action="simple_action", verbose=False
+    )
+    assert "verbosity: 4" not in sdk_client_fs.job_list()[0].log_list()[0].content

--- a/tests/plugin/test_steps_data/simple_action_cluster/config.yaml
+++ b/tests/plugin/test_steps_data/simple_action_cluster/config.yaml
@@ -1,0 +1,22 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- type: cluster
+  name: Dummy cluster
+  version: 1.5
+  actions:
+    simple_action:
+      type: job
+      script: simple_action.yaml
+      script_type: ansible
+      states:
+        available: any

--- a/tests/plugin/test_steps_data/simple_action_cluster/simple_action.yaml
+++ b/tests/plugin/test_steps_data/simple_action_cluster/simple_action.yaml
@@ -1,0 +1,21 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+- name: Simple dummy action
+  hosts: localhost
+  connection: local
+  gather_facts: no
+
+  tasks:
+    - name: Pass
+      debug:
+        msg: "Meant to pass"


### PR DESCRIPTION
Most of our tests use run_XXX_action_and_assert result method to run actions
We introduce --verbose-actions option that will add verbose=True option to all actions called with run_XXX_action_and_assert
If the custom value for verbose option will be passed directly to run_XXX_action_and_assert it will be used in first priority