### PR TITLE
QA-120 Factor DockerWrapper methods args to class

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     include_package_data=True,
-    version="4.1.3",
+    version="4.2.0",
     # the following makes a plugin available to pytest
     entry_points={"pytest11": ["adcm_pytest_plugin = adcm_pytest_plugin.plugin"]},
     # custom PyPI classifier for pytest plugins

--- a/src/adcm_pytest_plugin/docker_utils.py
+++ b/src/adcm_pytest_plugin/docker_utils.py
@@ -291,11 +291,17 @@ class ContainerConfig:
     image: str = "hub.arenadata.io/adcm/adcm"
     tag: str = "latest"
     pull: bool = True
-    labels: dict = field(default_factory=dict)
     remove: bool = True
+    labels: Optional[dict] = None
     ip: Optional[str] = None
     volumes: Optional[dict] = None
     name: Optional[str] = None
+
+    def __post_init__(self):
+        """Default values for some fields overwritten by None,
+        therefore we have to init them with expected defaults."""
+        self.ip = self.ip or DEFAULT_IP
+        self.labels = self.labels or {}
 
 
 class ADCM:
@@ -356,7 +362,7 @@ class DockerWrapper:
             pull=pull,
             name=name,
             tag=tag,
-            ip=ip or DEFAULT_IP,
+            ip=ip,
             volumes=volumes,
         )
         return self.run_adcm_from_config(config)
@@ -375,7 +381,6 @@ class DockerWrapper:
             self.client.images.pull(config.image, config.tag)
         if os.environ.get("BUILD_TAG"):
             config.labels.update({"jenkins-job": os.environ["BUILD_TAG"]})
-        config.ip = config.ip or DEFAULT_IP
 
         container, port = self.adcm_container_from_config(config)
 

--- a/src/adcm_pytest_plugin/docker_utils.py
+++ b/src/adcm_pytest_plugin/docker_utils.py
@@ -18,7 +18,7 @@ import socket
 import string
 import tarfile
 from contextlib import contextmanager
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from gzip import compress
 from typing import Optional
 

--- a/src/adcm_pytest_plugin/fixtures.py
+++ b/src/adcm_pytest_plugin/fixtures.py
@@ -126,7 +126,6 @@ def image(request, cmd_opts, adcm_api_credentials):
 def _adcm(image, cmd_opts, request, adcm_api_credentials) -> Generator[ADCM, None, None]:
     repo, tag = image
     labels = {"pytest_node_id": request.node.nodeid}
-    config = ContainerConfig(image=repo, tag=tag, pull=False, labels=labels)
     if cmd_opts.remote_docker:
         dw = DockerWrapper(base_url=f"tcp://{cmd_opts.remote_docker}")
         ip = cmd_opts.remote_docker.split(":")[0]
@@ -141,8 +140,8 @@ def _adcm(image, cmd_opts, request, adcm_api_credentials) -> Generator[ADCM, Non
                     "There is no obvious way to get external ip in this case."
                     "Try running container with pytest with --net=host option"
                 )
-    config.ip = ip or config.ip
-    adcm = dw.run_adcm(config)
+    config = ContainerConfig(image=repo, tag=tag, pull=False, ip=ip, labels=labels)
+    adcm = dw.run_adcm_from_config(config)
 
     yield adcm
 

--- a/src/adcm_pytest_plugin/fixtures.py
+++ b/src/adcm_pytest_plugin/fixtures.py
@@ -30,6 +30,7 @@ from requests.exceptions import ReadTimeout as DockerReadTimeout
 from .docker_utils import (
     ADCM,
     ADCMInitializer,
+    ContainerConfig,
     DockerWrapper,
     gather_adcm_data_from_container,
     is_docker,
@@ -124,6 +125,8 @@ def image(request, cmd_opts, adcm_api_credentials):
 
 def _adcm(image, cmd_opts, request, adcm_api_credentials) -> Generator[ADCM, None, None]:
     repo, tag = image
+    labels = {"pytest_node_id": request.node.nodeid}
+    config = ContainerConfig(image=repo, tag=tag, pull=False, labels=labels)
     if cmd_opts.remote_docker:
         dw = DockerWrapper(base_url=f"tcp://{cmd_opts.remote_docker}")
         ip = cmd_opts.remote_docker.split(":")[0]
@@ -138,13 +141,8 @@ def _adcm(image, cmd_opts, request, adcm_api_credentials) -> Generator[ADCM, Non
                     "There is no obvious way to get external ip in this case."
                     "Try running container with pytest with --net=host option"
                 )
-    adcm = dw.run_adcm(
-        image=repo,
-        tag=tag,
-        pull=False,
-        ip=ip,
-        labels={"pytest_node_id": request.node.nodeid},
-    )
+    config.ip = ip or config.ip
+    adcm = dw.run_adcm(config)
 
     yield adcm
 


### PR DESCRIPTION
There is a lot of duplicated arguments that should be passed across `DockerWrapper` class methods.
It worth to extract such arguments to the separate abstraction. `ContainerConfig` dataclass in the case.