### PR TITLE
QA-120 Add volume mounted as /adcm/data in adcm_xx

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     include_package_data=True,
-    version="4.2.0",
+    version="4.2.1",
     # the following makes a plugin available to pytest
     entry_points={"pytest11": ["adcm_pytest_plugin = adcm_pytest_plugin.plugin"]},
     # custom PyPI classifier for pytest plugins

--- a/src/adcm_pytest_plugin/docker_utils.py
+++ b/src/adcm_pytest_plugin/docker_utils.py
@@ -470,6 +470,7 @@ class DockerWrapper:
                     raise err
         raise RetryCountExceeded(f"Unable to start container after {CONTAINER_START_RETRY_COUNT} retries")
 
+
 def remove_docker_image(repo: str, tag: str, dc: DockerClient):
     """Remove docker image"""
     image_name = f"{repo}:{tag}"

--- a/tests/plugin/test_fixture.py
+++ b/tests/plugin/test_fixture.py
@@ -15,9 +15,12 @@ Tests for plugin fixtures.
 Does not contain tests with 'remote_executor_host', 'remote_docker', 'nopull' cmd opts
 WARNING: don't run this test with xdist!!!
 """
+from contextlib import suppress
+
 import allure
 import docker
-
+from adcm_pytest_plugin.docker_utils import remove_container_volumes
+from docker.errors import NotFound
 from requests.exceptions import ReadTimeout as DockerReadTimeout
 from tests.plugin.common import run_tests
 
@@ -111,13 +114,15 @@ def test_fixture_adcm_dontstop(testdir):
         if "test_fixture_adcm_dontstop.py::test_run_adcm" in line:
             line = line.split("'")
             repo_with_tag = ":".join([line[1], line[3]])
-    container_list = docker.from_env().containers.list(filters=dict(ancestor=repo_with_tag))
+    client = docker.from_env()
+    container_list = client.containers.list(filters=dict(ancestor=repo_with_tag))
 
     assert len(container_list) == 1, f"Not found running or created container with '{repo_with_tag}' ancestor"
 
     # Stop and remove ADCM container after test
     for container in container_list:
-        try:
+        with suppress(DockerReadTimeout):
             container.kill()
-        except DockerReadTimeout:
-            pass
+        with suppress(NotFound):
+            container.wait(condition="removed", timeout=30)
+        remove_container_volumes(container, client)


### PR DESCRIPTION
For upcoming `adcm_xx.upgrade` feature it's required to have mountpoint to `/adcm/data`.
Therefore `adcm_xx` fixtures will have volume attached by default.