### PR TITLE
'No such action ...' for object now is AssertionError

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     include_package_data=True,
-    version="4.5.0",
+    version="4.5.1",
     # the following makes a plugin available to pytest
     entry_points={"pytest11": ["adcm_pytest_plugin = adcm_pytest_plugin.plugin"]},
     # custom PyPI classifier for pytest plugins

--- a/src/adcm_pytest_plugin/steps/actions.py
+++ b/src/adcm_pytest_plugin/steps/actions.py
@@ -151,7 +151,9 @@ def _suggest_action_if_not_exists(obj: Union[Cluster, Service, Host, Component],
         if suggest_actions:
             raise ObjectNotFound(f"No such action {action}. Did you mean: {suggest_actions}?") from e
         all_actions = ", ".join(all_actions)
-        raise ObjectNotFound(f"No such action {action}. Possible actions: {all_actions}.") from e
+        raise AssertionError(
+            f"No such action {action}. {obj.__class__.__name__} state: {obj.state}. Possible actions: {all_actions}"
+        ) from e
 
 
 @allure.step("Wait for a task to be completed")


### PR DESCRIPTION
More often 'No such action ...' error is a product bug rather than a test developer mistake